### PR TITLE
fix: error when not informed license name or url

### DIFF
--- a/src/commands/readme-template-generator.ts
+++ b/src/commands/readme-template-generator.ts
@@ -397,11 +397,11 @@ const command: GluegunCommand = {
 
     const license: Types.License = {
       name:
-        githubRepository.api.index?.license.name ||
+        githubRepository.api.index?.license?.name ||
         read('LICENSE')?.split('\n')[0]?.trim() ||
         packageJSON?.license,
       url:
-        githubRepository.api.index?.license.url ||
+        githubRepository.api.index?.license?.url ||
         (githubRepository.url &&
           read('LICENSE') &&
           `${githubRepository.url}/blob/master/LICENSE`),


### PR DESCRIPTION
When the license name or url was not informed, the code snippet was trying to access the object 'name' or 'url' in a null object, causing an error.

![2022-11-23 07_45_55-readme-template-generator – readme-template-generator ts](https://user-images.githubusercontent.com/31248225/203529507-6374b74f-b239-4c17-8546-f6420dbd1bad.png)
